### PR TITLE
Fix api call timeout handling

### DIFF
--- a/api/admin/api_test.go
+++ b/api/admin/api_test.go
@@ -5,6 +5,8 @@ import (
 	"math/rand"
 	"os"
 	"strconv"
+	"strings"
+	"testing"
 	"time"
 )
 
@@ -22,4 +24,18 @@ func getTestSuffix() string {
 	}
 
 	return testSuffix
+}
+
+func TestApi_Timeout(t *testing.T) {
+	var originalTimeout = adminApi.Config.Api.Timeout
+
+	adminApi.Config.Api.Timeout = 0 // should timeout immediately
+
+	_, err := adminApi.Ping(ctx)
+
+	if err == nil || !strings.HasSuffix(err.Error(), "context deadline exceeded") {
+		t.Error("Expected context timeout did not happen")
+	}
+
+	adminApi.Config.Api.Timeout = originalTimeout
 }

--- a/api/uploader/upload.go
+++ b/api/uploader/upload.go
@@ -187,11 +187,6 @@ func (u *Api) postBody(ctx context.Context, urlPath interface{}, bodyBuf *bytes.
 
 	resp, err := u.client.Do(req)
 	if err != nil {
-		select {
-		case <-ctx.Done():
-			return nil, ctx.Err()
-		default:
-		}
 		return nil, err
 	}
 

--- a/api/uploader/upload_test.go
+++ b/api/uploader/upload_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/cloudinary/cloudinary-go/api"
@@ -101,6 +102,20 @@ func TestUploader_UploadBase64Image(t *testing.T) {
 	if resp == nil || resp.PublicID != publicID {
 		t.Error(resp)
 	}
+}
+
+func TestUploader_Timeout(t *testing.T) {
+	var originalTimeout = uploadApi.Config.Api.Timeout
+
+	uploadApi.Config.Api.Timeout = 0 // should timeout immediately
+
+	_, err := uploadApi.Upload(ctx, LogoUrl, UploadParams{})
+
+	if err == nil || !strings.HasSuffix(err.Error(), "context deadline exceeded") {
+		t.Error("Expected context timeout did not happen")
+	}
+
+	uploadApi.Config.Api.Timeout = originalTimeout
 }
 
 func UploadTestAsset(t *testing.T, publicID string) {


### PR DESCRIPTION
### Brief Summary of Changes

Add support for timeout in  Admin API.

Fix redundant `ctx` error handling.

<!-- Provide some context as to what was changed, from an implementation standpoint. -->

#### What does this PR address?

- [ ] GitHub issue (Add reference - #XX)
- [ ] Refactoring
- [x] New feature
- [x] Bug fix
- [ ] Adds more tests

#### Are tests included?

- [x] Yes
- [ ] No

#### Reviewer, please note:

<!--
List anything here that the reviewer should pay special attention to. This might
include, for example:
* Dependence on other PRs
* Reference to other Cloudinary SDKs
* Changes that seem arbitrary without further explanations
-->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I ran the full test suite before pushing the changes and all the tests pass.
