### PR TITLE
Adding NextCursor field to search API result

### DIFF
--- a/api/admin/search.go
+++ b/api/admin/search.go
@@ -36,6 +36,7 @@ type SearchResult struct {
 	Time       int           `json:"time"`
 	Assets     []SearchAsset `json:"resources"`
 	Error      api.ErrorResp `json:"error,omitempty"`
+	NextCursor string `json:"next_cursor,omitempty"`
 }
 
 // SearchAsset represents the details of a single asset that was found.


### PR DESCRIPTION
### Brief Summary of Changes

Search API do not return NextCursor field, which is important for sending search request from the same source for more images.

#### What does this PR address?

- [ ] GitHub issue (Add reference - #XX)
- [ ] Refactoring
- [x] New feature
- [ ] Bug fix
- [ ] Adds more tests

#### Are tests included?

- [ ] Yes
- [x] No

#### Reviewer, please note:


#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I ran the full test suite before pushing the changes and all the tests pass.
