### PR TITLE
WIP: PoC of request/response testing with table-driven approach

### DIFF
--- a/api/admin/api.go
+++ b/api/admin/api.go
@@ -31,6 +31,11 @@ func New() (*API, error) {
 	if err != nil {
 		return nil, err
 	}
+	return NewWithConfiguration(c)
+}
+
+// NewWithConfiguration a new Admin API instance with the given Configuration
+func NewWithConfiguration(c *config.Configuration) (*API, error) {
 	return &API{
 		Config: *c,
 		client: http.Client{},

--- a/api/admin/api_test.go
+++ b/api/admin/api_test.go
@@ -2,6 +2,13 @@ package admin_test
 
 import (
 	"context"
+	"github.com/cloudinary/cloudinary-go/config"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -10,6 +17,20 @@ import (
 
 var ctx = context.Background()
 var adminAPI, _ = admin.New()
+
+type ApiTestRequest func(api *admin.API, ctx context.Context) (interface{}, error)
+type ApiTestResponse func(response interface{}, t *testing.T)
+type ApiAcceptanceTestCase struct {
+	Name              string
+	TestRequest       ApiTestRequest
+	TestResponse      ApiTestResponse
+	ExpectedRequest   expectedRequestParams
+	JsonResponse      string
+	ExpectedStatus    string
+	ExpectedCallCount int
+}
+
+const apiVersion = "v1_1"
 
 func TestAPI_Timeout(t *testing.T) {
 	var originalTimeout = adminAPI.Config.API.Timeout
@@ -23,4 +44,170 @@ func TestAPI_Timeout(t *testing.T) {
 	}
 
 	adminAPI.Config.API.Timeout = originalTimeout
+}
+
+func getPingTestCases() []ApiAcceptanceTestCase {
+	return []ApiAcceptanceTestCase{
+		{
+			Name: "Ping",
+			TestRequest: func(api *admin.API, ctx context.Context) (interface{}, error) {
+				return api.Ping(ctx)
+			},
+			TestResponse: func(response interface{}, t *testing.T) {
+				_, ok := response.(*admin.PingResult)
+				if !ok {
+					t.Errorf("Response should be type of PingResult, %s given", reflect.TypeOf(response))
+				}
+			},
+			ExpectedRequest:   expectedRequestParams{Method: "GET", Uri: "/ping"},
+			JsonResponse:      "{\"status\": \"OK\"}",
+			ExpectedCallCount: 1,
+		},
+		{
+			Name: "Ping error check",
+			TestRequest: func(api *admin.API, ctx context.Context) (interface{}, error) {
+				return api.Ping(ctx)
+			},
+			TestResponse: func(response interface{}, t *testing.T) {
+				v, ok := response.(*admin.PingResult)
+				if !ok {
+					t.Errorf("Response should be type %s, %s given", reflect.TypeOf(admin.PingResult{}), reflect.TypeOf(response))
+				} else {
+					if v.Status == "OK" {
+						t.Error("Response status should not be OK")
+					}
+
+					if v.Error.Message != "ERROR MESSAGE" {
+						t.Errorf("Error message should be %s, %s given", "ERROR MESSAGE", v.Error.Message)
+					}
+				}
+			},
+			ExpectedRequest:   expectedRequestParams{Method: "GET", Uri: "/ping"},
+			JsonResponse:      "{\"error\":{\"message\": \"ERROR MESSAGE\"}}",
+			ExpectedCallCount: 1,
+		},
+		{
+			Name: "Ping result struct check",
+			TestRequest: func(api *admin.API, ctx context.Context) (interface{}, error) {
+				return api.Ping(ctx)
+			},
+			TestResponse: func(response interface{}, t *testing.T) {
+				v, ok := response.(*admin.PingResult)
+				if ok {
+					if v.Status != "OK" {
+						t.Errorf("Status should be %s, %s given\n", "OK", v.Status)
+					}
+				} else {
+					t.Errorf("Response should be type %s, %s given", reflect.TypeOf(admin.PingResult{}), reflect.TypeOf(response))
+				}
+			},
+			ExpectedRequest:   expectedRequestParams{Method: "GET", Uri: "/ping"},
+			JsonResponse:      "{\"status\":\"OK\"}",
+			ExpectedCallCount: 1,
+		},
+	}
+}
+
+func TestAPI_Acceptance(t *testing.T) {
+	t.Parallel()
+	testApiByTestCases(getPingTestCases(), t)
+}
+
+func testApiByTestCases(cases []ApiAcceptanceTestCase, t *testing.T) {
+	for num, test := range cases {
+		if test.Name == "" {
+			t.Skipf("Test name should be set for test #%d. Skipping it.", num)
+		}
+
+		t.Run(test.Name, func(t *testing.T) {
+			callCounter := 0
+			srv := getServerMock(getTestHandler(test.JsonResponse, t, &callCounter, test.ExpectedRequest))
+
+			res, _ := test.TestRequest(getTestableApi(srv.URL, t), ctx)
+			test.TestResponse(res, t)
+
+			if callCounter != test.ExpectedCallCount {
+				t.Errorf("Expected %d call, %d given", test.ExpectedCallCount, callCounter)
+			}
+
+			srv.Close()
+		})
+	}
+}
+
+type testFunction func(w http.ResponseWriter, r *http.Request)
+type expectedRequestParams struct {
+	Method  string
+	Uri     string
+	Params  *url.Values
+	Body    *string
+	Headers *map[string]string
+}
+
+func getTestHandler(response string, t *testing.T, callCounter *int, ep expectedRequestParams) testFunction {
+	return func(w http.ResponseWriter, r *http.Request) {
+
+		if r.Method != ep.Method {
+			t.Errorf("HTTP method should be %s", ep.Method)
+		}
+
+		if ep.Params != nil && ep.Params.Encode() != r.URL.Query().Encode() {
+			t.Errorf(
+				"Expected query string: %s, got: %s\n",
+				ep.Params.Encode(),
+				r.URL.Query().Encode(),
+			)
+		}
+
+		expectedURI := "/" + apiVersion + "/TEST" + ep.Uri
+		if expectedURI != r.URL.Path {
+			t.Errorf(
+				"Expected request URI: %s, got: %s\n",
+				expectedURI,
+				r.URL.Path,
+			)
+		}
+
+		if r.Method == http.MethodPost || r.Method == http.MethodPut || r.Method == http.MethodDelete {
+			if r.Body != nil && ep.Body != nil {
+				bodyString, err := ioutil.ReadAll(r.Body)
+
+				if err != nil {
+					t.Error(err)
+				}
+
+				if string(bodyString) != *ep.Body {
+					t.Errorf("Wrong request body. Expected: %s, given: %s", *ep.Body, string(bodyString))
+				}
+			}
+		}
+
+		*callCounter++
+		io.WriteString(w, response)
+	}
+}
+func getTestableApi(mockServerUrl string, t *testing.T) *admin.API {
+	c, err := config.NewFromParams("TEST", "", "")
+	if err != nil {
+		t.Error(err)
+	}
+
+	c.API.UploadPrefix = mockServerUrl
+
+	api, err := admin.NewWithConfiguration(c)
+	if err != nil {
+		t.Error(err)
+	}
+
+	return api
+}
+func getServerMock(fn testFunction) *httptest.Server {
+	handler := http.NewServeMux()
+	handler.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		fn(w, r)
+	})
+
+	srv := httptest.NewServer(handler)
+
+	return srv
 }

--- a/api/admin/assets_test.go
+++ b/api/admin/assets_test.go
@@ -1,6 +1,11 @@
 package admin_test
 
 import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"reflect"
 	"testing"
 
 	"github.com/cloudinary/cloudinary-go/api"
@@ -48,8 +53,603 @@ func TestAssets_RestoreAssets(t *testing.T) {
 }
 
 func TestAssets_DeleteAssets(t *testing.T) {
-	resp, err := adminAPI.DeleteAssets(ctx, admin.DeleteAssetsParams{PublicIDs: []string{"api_test_restore_20891", "api_test_restore_94060"}})
+	resp, err :=
+		adminAPI.DeleteAssets(ctx, admin.DeleteAssetsParams{PublicIDs: []string{"api_test_restore_20891", "api_test_restore_94060"}})
 	if err != nil {
 		t.Error(err, resp)
 	}
+}
+func getRestoreAssetsTestCases() []ApiAcceptanceTestCase {
+	type restoreAssetsTestCase struct {
+		requestParams admin.RestoreAssetsParams
+		uri           string
+		expectedBody  string
+	}
+
+	getTestCase := func(num int, t restoreAssetsTestCase) ApiAcceptanceTestCase {
+		return ApiAcceptanceTestCase{
+			Name: fmt.Sprintf("RestoreAssets #%d", num),
+			TestRequest: func(api *admin.API, ctx context.Context) (interface{}, error) {
+				return api.RestoreAssets(ctx, t.requestParams)
+			},
+			TestResponse: func(response interface{}, t *testing.T) {
+				_, ok := response.(*admin.RestoreAssetsResult)
+				if !ok {
+					t.Errorf("Response should be type of RestoreAssetsResult, %s given", reflect.TypeOf(response))
+				}
+			},
+			ExpectedRequest: expectedRequestParams{
+				Method: "POST",
+				Uri:    t.uri,
+				Body:   &t.expectedBody,
+			},
+			JsonResponse:      "{}",
+			ExpectedCallCount: 1,
+		}
+	}
+
+	testCases := []ApiAcceptanceTestCase{}
+
+	restoreAssetsTestCases := []restoreAssetsTestCase{
+		{
+			requestParams: admin.RestoreAssetsParams{},
+			uri:           "/resources/image/upload/restore",
+			expectedBody:  "{\"public_ids\":\"\",\"versions\":\"\"}",
+		},
+		{
+			requestParams: admin.RestoreAssetsParams{
+				AssetType: "ASSET_TYPE",
+			},
+			uri:          "/resources/ASSET_TYPE/upload/restore",
+			expectedBody: "{\"public_ids\":\"\",\"versions\":\"\"}",
+		},
+		{
+			requestParams: admin.RestoreAssetsParams{
+				AssetType:    "ASSET_TYPE",
+				DeliveryType: "DELIVERY_TYPE",
+			},
+			uri:          "/resources/ASSET_TYPE/DELIVERY_TYPE/restore",
+			expectedBody: "{\"public_ids\":\"\",\"versions\":\"\"}",
+		},
+		{
+			requestParams: admin.RestoreAssetsParams{
+				AssetType:    "ASSET_TYPE",
+				DeliveryType: "DELIVERY_TYPE",
+				PublicIDs:    []string{"1", "2"},
+			},
+			uri:          "/resources/ASSET_TYPE/DELIVERY_TYPE/restore",
+			expectedBody: "{\"public_ids\":\"1,2\",\"versions\":\"\"}",
+		},
+		{
+			requestParams: admin.RestoreAssetsParams{
+				AssetType:    "ASSET_TYPE",
+				DeliveryType: "DELIVERY_TYPE",
+				PublicIDs:    []string{"1", "2"},
+				Versions:     []string{"3", "4"},
+			},
+			uri:          "/resources/ASSET_TYPE/DELIVERY_TYPE/restore",
+			expectedBody: "{\"public_ids\":\"1,2\",\"versions\":\"3,4\"}",
+		},
+	}
+
+	for num, testCase := range restoreAssetsTestCases {
+		testCases = append(testCases, getTestCase(num, testCase))
+	}
+
+	asset := api.BriefAssetResult{AssetID: "1"}
+	response := map[string]api.BriefAssetResult{"1": asset}
+	responseJson, _ := json.Marshal(response)
+
+	testCases = append(testCases, ApiAcceptanceTestCase{
+		Name: "RestoreAssets response parsing case",
+		TestRequest: func(api *admin.API, ctx context.Context) (interface{}, error) {
+			return api.RestoreAssets(ctx, admin.RestoreAssetsParams{})
+		},
+		TestResponse: func(response interface{}, t *testing.T) {
+			v, ok := response.(*admin.RestoreAssetsResult)
+			if !ok {
+				t.Errorf("Response should be type of RestoreAssetsResult, %s given", reflect.TypeOf(response))
+			}
+
+			directMap := *v
+			if responseAsset, ok := directMap["1"]; ok {
+				if !reflect.DeepEqual(directMap["1"], asset) {
+					t.Errorf("Response asset should be %v, %v given", asset, responseAsset)
+				}
+			} else {
+				t.Errorf("Asset #1 is not found in response %v", v)
+			}
+		},
+
+		ExpectedRequest: expectedRequestParams{
+			Method: "POST",
+			Uri:    "/resources/image/upload/restore",
+		},
+		JsonResponse:      string(responseJson),
+		ExpectedCallCount: 1,
+	},
+	)
+
+	return testCases
+}
+
+func getDeleteAssetsTestCases() []ApiAcceptanceTestCase {
+	type deleteAssetsTestCase struct {
+		requestParams admin.DeleteAssetsParams
+		uri           string
+		expectedBody  string
+	}
+
+	getTestCase := func(num int, t deleteAssetsTestCase) ApiAcceptanceTestCase {
+		return ApiAcceptanceTestCase{
+			Name: fmt.Sprintf("DeleteAssets #%d", num),
+			TestRequest: func(api *admin.API, ctx context.Context) (interface{}, error) {
+				return api.DeleteAssets(ctx, t.requestParams)
+			},
+			TestResponse: func(response interface{}, t *testing.T) {
+				_, ok := response.(*admin.DeleteAssetsResult)
+				if !ok {
+					t.Errorf("Response should be type of DeleteAssetsResult, %s given", reflect.TypeOf(response))
+				}
+			},
+			ExpectedRequest: expectedRequestParams{
+				Method: "DELETE",
+				Uri:    t.uri,
+				Body:   &t.expectedBody,
+			},
+			JsonResponse:      "{}",
+			ExpectedCallCount: 1,
+		}
+	}
+
+	testCases := []ApiAcceptanceTestCase{}
+
+	restoreAssetsTestCases := []deleteAssetsTestCase{
+		{
+			requestParams: admin.DeleteAssetsParams{},
+			uri:           "/resources/image/upload",
+			expectedBody:  "{\"public_ids\":\"\"}",
+		},
+		{
+			requestParams: admin.DeleteAssetsParams{
+				AssetType: "ASSET_TYPE",
+			},
+			uri:          "/resources/ASSET_TYPE/upload",
+			expectedBody: "{\"public_ids\":\"\"}",
+		},
+		{
+			requestParams: admin.DeleteAssetsParams{
+				AssetType:    "ASSET_TYPE",
+				DeliveryType: "DELIVERY_TYPE",
+			},
+			uri:          "/resources/ASSET_TYPE/DELIVERY_TYPE",
+			expectedBody: "{\"public_ids\":\"\"}",
+		},
+		{
+			requestParams: admin.DeleteAssetsParams{
+				AssetType:    "ASSET_TYPE",
+				DeliveryType: "DELIVERY_TYPE",
+				PublicIDs:    []string{"1", "2"},
+			},
+			uri:          "/resources/ASSET_TYPE/DELIVERY_TYPE",
+			expectedBody: "{\"public_ids\":\"1,2\"}",
+		},
+		{
+			requestParams: admin.DeleteAssetsParams{
+				AssetType:    "ASSET_TYPE",
+				DeliveryType: "DELIVERY_TYPE",
+				PublicIDs:    []string{"1", "2"},
+				KeepOriginal: false,
+			},
+			uri:          "/resources/ASSET_TYPE/DELIVERY_TYPE",
+			expectedBody: "{\"public_ids\":\"1,2\"}",
+		},
+		{
+			requestParams: admin.DeleteAssetsParams{
+				AssetType:    "ASSET_TYPE",
+				DeliveryType: "DELIVERY_TYPE",
+				PublicIDs:    []string{"1", "2"},
+				KeepOriginal: true,
+			},
+			uri:          "/resources/ASSET_TYPE/DELIVERY_TYPE",
+			expectedBody: "{\"public_ids\":\"1,2\",\"keep_original\":true}",
+		},
+		{
+			requestParams: admin.DeleteAssetsParams{
+				AssetType:    "ASSET_TYPE",
+				DeliveryType: "DELIVERY_TYPE",
+				PublicIDs:    []string{"1", "2"},
+				KeepOriginal: true,
+				Invalidate:   false,
+			},
+			uri:          "/resources/ASSET_TYPE/DELIVERY_TYPE",
+			expectedBody: "{\"public_ids\":\"1,2\",\"keep_original\":true}",
+		},
+		{
+			requestParams: admin.DeleteAssetsParams{
+				AssetType:    "ASSET_TYPE",
+				DeliveryType: "DELIVERY_TYPE",
+				PublicIDs:    []string{"1", "2"},
+				KeepOriginal: true,
+				Invalidate:   true,
+			},
+			uri:          "/resources/ASSET_TYPE/DELIVERY_TYPE",
+			expectedBody: "{\"public_ids\":\"1,2\",\"keep_original\":true,\"invalidate\":true}",
+		},
+		{
+			requestParams: admin.DeleteAssetsParams{
+				AssetType:       "ASSET_TYPE",
+				DeliveryType:    "DELIVERY_TYPE",
+				PublicIDs:       []string{"1", "2"},
+				Transformations: "TEST_TRANSFORMATIONS",
+			},
+			uri:          "/resources/ASSET_TYPE/DELIVERY_TYPE",
+			expectedBody: "{\"public_ids\":\"1,2\",\"transformations\":\"TEST_TRANSFORMATIONS\"}",
+		},
+		{
+			requestParams: admin.DeleteAssetsParams{
+				AssetType:    "ASSET_TYPE",
+				DeliveryType: "DELIVERY_TYPE",
+				PublicIDs:    []string{"1", "2"},
+				NextCursor:   "NEXT_CURSOR",
+			},
+			uri:          "/resources/ASSET_TYPE/DELIVERY_TYPE",
+			expectedBody: "{\"public_ids\":\"1,2\",\"next_cursor\":\"NEXT_CURSOR\"}",
+		},
+	}
+
+	for num, testCase := range restoreAssetsTestCases {
+		testCases = append(testCases, getTestCase(num, testCase))
+	}
+
+	testCases = append(testCases, ApiAcceptanceTestCase{
+		Name: "DeleteAssets error case",
+		TestRequest: func(api *admin.API, ctx context.Context) (interface{}, error) {
+			return api.DeleteAssets(ctx, admin.DeleteAssetsParams{})
+		},
+		TestResponse: func(response interface{}, t *testing.T) {
+			v, ok := response.(*admin.DeleteAssetsResult)
+			if !ok {
+				t.Errorf("Response should be type of DeleteAssetsResult, %s given", reflect.TypeOf(response))
+			}
+
+			if v.Error.Message != "TEST ERROR" {
+				t.Errorf("Error message should be %s, %s given", "TEST ERROR", v.Error.Message)
+			}
+		},
+		ExpectedRequest: expectedRequestParams{
+			Method: "DELETE",
+			Uri:    "/resources/image/upload",
+		},
+		JsonResponse:      "{\"error\":{\"message\":\"TEST ERROR\"}}",
+		ExpectedCallCount: 1,
+	})
+
+	response := map[string]interface{}{
+		"deleted":        map[string]string{"1": "TEST", "2": "TEST_2"},
+		"deleted_counts": map[string]interface{}{"1": 1, "2": "2"},
+		"partial":        true,
+	}
+	responseJson, _ := json.Marshal(response)
+
+	testCases = append(testCases, ApiAcceptanceTestCase{
+		Name: "DeleteAssets response parsing case",
+		TestRequest: func(api *admin.API, ctx context.Context) (interface{}, error) {
+			return api.DeleteAssets(ctx, admin.DeleteAssetsParams{})
+		},
+		TestResponse: func(response interface{}, t *testing.T) {
+			v, ok := response.(*admin.DeleteAssetsResult)
+			if !ok {
+				t.Errorf("Response should be type of DeleteAssetsResult, %s given", reflect.TypeOf(response))
+			}
+
+			expectedResponse := &admin.DeleteAssetsResult{
+				Deleted:       map[string]string{"1": "TEST", "2": "TEST_2"},
+				DeletedCounts: map[string]interface{}{"1": 1, "2": "2"},
+				Partial:       true,
+			}
+
+			// ugly solution for map[string]interface{} below. deepequal does not work for this case :(
+			if !reflect.DeepEqual(expectedResponse.Deleted, v.Deleted) {
+				t.Errorf("Response.Deleted expected to be %v, %v given", expectedResponse.Deleted, v.Deleted)
+			}
+
+			if expectedResponse.Partial != v.Partial {
+				t.Errorf("Response.Partial expected to be %v, %v given", expectedResponse.Partial, v.Partial)
+			}
+
+			if fmt.Sprintf("%v", expectedResponse.DeletedCounts) != fmt.Sprintf("%v", v.DeletedCounts) {
+				t.Errorf("Response.DeletedCounts expected to be %v, %v given", expectedResponse.DeletedCounts, v.DeletedCounts)
+			}
+		},
+		ExpectedRequest: expectedRequestParams{
+			Method: "DELETE",
+			Uri:    "/resources/image/upload",
+		},
+		JsonResponse:      string(responseJson),
+		ExpectedCallCount: 1,
+	})
+
+	return testCases
+}
+
+func getAssetsByModerationTestCases() []ApiAcceptanceTestCase {
+	type assetByModerationTestCase struct {
+		requestParams  admin.AssetsByModerationParams
+		uri            string
+		expectedParams *url.Values
+	}
+
+	getTestCase := func(num int, t assetByModerationTestCase) ApiAcceptanceTestCase {
+		return ApiAcceptanceTestCase{
+			Name: fmt.Sprintf("AssetsByModeration #%d", num),
+			TestRequest: func(api *admin.API, ctx context.Context) (interface{}, error) {
+				return api.AssetsByModeration(ctx, t.requestParams)
+			},
+			TestResponse: func(response interface{}, t *testing.T) {
+				_, ok := response.(*admin.AssetsResult)
+				if !ok {
+					t.Errorf("Response should be type of AssetsResult, %s given", reflect.TypeOf(response))
+				}
+			},
+			ExpectedRequest: expectedRequestParams{
+				Method: "GET",
+				Uri:    t.uri,
+				Params: t.expectedParams,
+			},
+			JsonResponse:      "{}",
+			ExpectedCallCount: 1,
+		}
+	}
+
+	testCases := []ApiAcceptanceTestCase{}
+
+	assetByModerationTestCases := []assetByModerationTestCase{
+		{
+			requestParams:  admin.AssetsByModerationParams{},
+			uri:            "/resources/image/moderations",
+			expectedParams: &url.Values{},
+		},
+		{
+			requestParams: admin.AssetsByModerationParams{
+				AssetType: "ASSET_TYPE",
+			},
+			uri:            "/resources/ASSET_TYPE/moderations",
+			expectedParams: &url.Values{},
+		},
+		{
+			requestParams: admin.AssetsByModerationParams{
+				AssetType: "ASSET_TYPE",
+				Kind:      "KIND",
+			},
+			uri:            "/resources/ASSET_TYPE/moderations/KIND",
+			expectedParams: &url.Values{},
+		},
+		{
+			requestParams: admin.AssetsByModerationParams{
+				AssetType: "ASSET_TYPE",
+				Kind:      "KIND",
+				Status:    "STATUS",
+			},
+			uri:            "/resources/ASSET_TYPE/moderations/KIND/STATUS",
+			expectedParams: &url.Values{},
+		},
+		{
+			requestParams: admin.AssetsByModerationParams{
+				AssetType:  "ASSET_TYPE",
+				Kind:       "KIND",
+				Status:     "STATUS",
+				NextCursor: "NEXT_CURSOR",
+			},
+			uri: "/resources/ASSET_TYPE/moderations/KIND/STATUS",
+			expectedParams: &url.Values{
+				"next_cursor": []string{"NEXT_CURSOR"},
+			},
+		},
+		{
+			requestParams: admin.AssetsByModerationParams{
+				AssetType:  "ASSET_TYPE",
+				Kind:       "KIND",
+				Status:     "STATUS",
+				NextCursor: "NEXT_CURSOR",
+				MaxResults: 100,
+			},
+			uri: "/resources/ASSET_TYPE/moderations/KIND/STATUS",
+			expectedParams: &url.Values{
+				"next_cursor": []string{"NEXT_CURSOR"},
+				"max_results": []string{"100"},
+			},
+		},
+		{
+			requestParams: admin.AssetsByModerationParams{
+				AssetType:  "ASSET_TYPE",
+				Kind:       "KIND",
+				Status:     "STATUS",
+				NextCursor: "NEXT_CURSOR",
+				MaxResults: 100,
+				Tags:       true,
+			},
+			uri: "/resources/ASSET_TYPE/moderations/KIND/STATUS",
+			expectedParams: &url.Values{
+				"next_cursor": []string{"NEXT_CURSOR"},
+				"max_results": []string{"100"},
+				"tags":        []string{"true"},
+			},
+		},
+		{
+			requestParams: admin.AssetsByModerationParams{
+				AssetType:  "ASSET_TYPE",
+				Kind:       "KIND",
+				Status:     "STATUS",
+				NextCursor: "NEXT_CURSOR",
+				MaxResults: 100,
+				Tags:       false,
+			},
+			uri: "/resources/ASSET_TYPE/moderations/KIND/STATUS",
+			expectedParams: &url.Values{
+				"next_cursor": []string{"NEXT_CURSOR"},
+				"max_results": []string{"100"},
+			},
+		},
+		{
+			requestParams: admin.AssetsByModerationParams{
+				AssetType:  "ASSET_TYPE",
+				Kind:       "KIND",
+				Status:     "STATUS",
+				NextCursor: "NEXT_CURSOR",
+				MaxResults: 100,
+				Tags:       false,
+				Context:    true,
+			},
+			uri: "/resources/ASSET_TYPE/moderations/KIND/STATUS",
+			expectedParams: &url.Values{
+				"next_cursor": []string{"NEXT_CURSOR"},
+				"max_results": []string{"100"},
+				"context":     []string{"true"},
+			},
+		},
+		{
+			requestParams: admin.AssetsByModerationParams{
+				AssetType:  "ASSET_TYPE",
+				Kind:       "KIND",
+				Status:     "STATUS",
+				NextCursor: "NEXT_CURSOR",
+				MaxResults: 100,
+				Tags:       false,
+				Context:    false,
+			},
+			uri: "/resources/ASSET_TYPE/moderations/KIND/STATUS",
+			expectedParams: &url.Values{
+				"next_cursor": []string{"NEXT_CURSOR"},
+				"max_results": []string{"100"},
+			},
+		},
+		{
+			requestParams: admin.AssetsByModerationParams{
+				AssetType:   "ASSET_TYPE",
+				Kind:        "KIND",
+				Status:      "STATUS",
+				NextCursor:  "NEXT_CURSOR",
+				MaxResults:  100,
+				Tags:        false,
+				Context:     false,
+				Moderations: true,
+			},
+			uri: "/resources/ASSET_TYPE/moderations/KIND/STATUS",
+			expectedParams: &url.Values{
+				"next_cursor": []string{"NEXT_CURSOR"},
+				"max_results": []string{"100"},
+				"moderations": []string{"true"},
+			},
+		},
+		{
+			requestParams: admin.AssetsByModerationParams{
+				AssetType:   "ASSET_TYPE",
+				Kind:        "KIND",
+				Status:      "STATUS",
+				NextCursor:  "NEXT_CURSOR",
+				MaxResults:  100,
+				Tags:        false,
+				Context:     false,
+				Moderations: false,
+			},
+			uri: "/resources/ASSET_TYPE/moderations/KIND/STATUS",
+			expectedParams: &url.Values{
+				"next_cursor": []string{"NEXT_CURSOR"},
+				"max_results": []string{"100"},
+			},
+		},
+		{
+			requestParams: admin.AssetsByModerationParams{
+				AssetType:   "ASSET_TYPE",
+				Kind:        "KIND",
+				Status:      "STATUS",
+				NextCursor:  "NEXT_CURSOR",
+				MaxResults:  100,
+				Tags:        false,
+				Context:     false,
+				Moderations: false,
+				Direction:   "ASC",
+			},
+			uri: "/resources/ASSET_TYPE/moderations/KIND/STATUS",
+			expectedParams: &url.Values{
+				"next_cursor": []string{"NEXT_CURSOR"},
+				"max_results": []string{"100"},
+				"direction":   []string{"ASC"},
+			},
+		},
+	}
+
+	for num, testCase := range assetByModerationTestCases {
+		testCases = append(testCases, getTestCase(num, testCase))
+	}
+
+	testCases = append(testCases, ApiAcceptanceTestCase{
+		Name: "AssetsByModeration error case",
+		TestRequest: func(api *admin.API, ctx context.Context) (interface{}, error) {
+			return api.AssetsByModeration(ctx, admin.AssetsByModerationParams{})
+		},
+		TestResponse: func(response interface{}, t *testing.T) {
+			v, ok := response.(*admin.AssetsResult)
+			if !ok {
+				t.Errorf("Response should be type of AssetsResult, %s given", reflect.TypeOf(response))
+			}
+
+			if v.Error.Message != "TEST ERROR" {
+				t.Errorf("Error message should be %s, %s given", "TEST ERROR", v.Error.Message)
+			}
+		},
+		ExpectedRequest: expectedRequestParams{
+			Method: "GET",
+			Uri:    "/resources/image/moderations",
+			Params: &url.Values{},
+		},
+		JsonResponse:      "{\"error\":{\"message\": \"TEST ERROR\"}}",
+		ExpectedCallCount: 1,
+	})
+
+	asset := api.BriefAssetResult{AssetID: "1"}
+	response := map[string]interface{}{
+		"resources":   []api.BriefAssetResult{asset},
+		"next_cursor": "NEXT_CURSOR",
+	}
+	responseJson, _ := json.Marshal(response)
+
+	testCases = append(testCases, ApiAcceptanceTestCase{
+		Name: "AssetsByModeration response parsing case",
+		TestRequest: func(api *admin.API, ctx context.Context) (interface{}, error) {
+			return api.AssetsByModeration(ctx, admin.AssetsByModerationParams{})
+		},
+		TestResponse: func(response interface{}, t *testing.T) {
+			expectedResponse := admin.AssetsResult{
+				Assets:     []api.BriefAssetResult{asset},
+				NextCursor: "NEXT_CURSOR",
+			}
+
+			v, ok := response.(*admin.AssetsResult)
+			if !ok {
+				t.Errorf("Response should be type of %s, %s given", reflect.TypeOf(expectedResponse), reflect.TypeOf(response))
+			}
+
+			if !reflect.DeepEqual(expectedResponse, *v) {
+				t.Errorf("Expected response to be %v, %v given", expectedResponse, v)
+			}
+		},
+		ExpectedRequest: expectedRequestParams{
+			Method: "GET",
+			Uri:    "/resources/image/moderations",
+			Params: &url.Values{},
+		},
+		JsonResponse:      string(responseJson),
+		ExpectedCallCount: 1,
+	})
+
+	return testCases
+}
+
+func TestAssets_Acceptance(t *testing.T) {
+	t.Parallel()
+	testApiByTestCases(getAssetsByModerationTestCases(), t)
+	testApiByTestCases(getDeleteAssetsTestCases(), t)
+	testApiByTestCases(getRestoreAssetsTestCases(), t)
 }


### PR DESCRIPTION
### Brief Summary of Changes

Request/response tests added for couple of functions.
This tests uses table-driven approach (see article https://dave.cheney.net/2019/05/07/prefer-table-driven-tests for example) + http mock server.

You can use template "^*Acceptance*$" to run only new tests. They does not require internet connection to run (as server is mocked) and tests request forming + response parsing.

This is just a PoC - some things still need to be polished before we can write new tests in this style.

<!-- Provide some context as to what was changed, from an implementation standpoint. -->

#### What does this PR address?

- [ ] GitHub issue (Add reference - #XX)
- [ ] Refactoring
- [ ] New feature
- [ ] Bug fix
- [x] Adds more tests

#### Are tests included?

- [x] Yes
- [ ] No

#### Reviewer, please note:

<!--
List anything here that the reviewer should pay special attention to. This might
include, for example:
* Dependence on other PRs
* Reference to other Cloudinary SDKs
* Changes that seem arbitrary without further explanations
-->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I ran the full test suite before pushing the changes and all the tests pass.
