### PR TITLE
Upload: Only sign required params

### DIFF
--- a/api/uploader/upload_test.go
+++ b/api/uploader/upload_test.go
@@ -3,12 +3,13 @@ package uploader_test
 import (
 	"context"
 	"fmt"
-	"github.com/stretchr/testify/assert"
 	"io/ioutil"
 	"log"
 	"os"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 
 	"github.com/cloudinary/cloudinary-go/api"
 	"github.com/cloudinary/cloudinary-go/api/uploader"
@@ -83,6 +84,23 @@ func TestUploader_UploadURL(t *testing.T) {
 	}
 
 	if resp == nil || resp.PublicID != cldtest.PublicID {
+		t.Error(resp)
+	}
+}
+
+func TestUploader_UploadVideoURL(t *testing.T) {
+	params := uploader.UploadParams{
+		PublicID:     cldtest.PublicID,
+		ResourceType: "video",
+		Overwrite:    true,
+	}
+
+	resp, err := uploadAPI.Upload(ctx, cldtest.VideoURL, params)
+
+	if err != nil {
+		t.Error(err)
+	}
+	if resp == nil || resp.PublicID != cldtest.PublicID || resp.Error.Message != "" {
 		t.Error(resp)
 	}
 }

--- a/internal/cldtest/cldtest.go
+++ b/internal/cldtest/cldtest.go
@@ -3,7 +3,6 @@ package cldtest
 import (
 	"context"
 	"fmt"
-	"github.com/cloudinary/cloudinary-go/api/uploader"
 	"math/rand"
 	"os"
 	"path"
@@ -12,10 +11,15 @@ import (
 	"strconv"
 	"testing"
 	"time"
+
+	"github.com/cloudinary/cloudinary-go/api/uploader"
 )
 
 // LogoURL is the URL of the publicly available logo.
 const LogoURL = "https://cloudinary-res.cloudinary.com/image/upload/cloudinary_logo.png"
+
+// VideoURL is the URL of the publicly available video.
+const VideoURL = "https://res.cloudinary.com/demo/video/upload/dog.mp4"
 
 // Base64Image us a base64 encoded test image.
 const Base64Image = "data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7"


### PR DESCRIPTION
### Brief Summary of Changes

The Upload API request signing includes all passed parameters to the signing method, despite [the documentation](https://cloudinary.com/documentation/upload_images#generating_authentication_signatures) clearly states that `All parameters added to the method call should be included except: file, cloud_name, resource_type and your api_key.`
The server rejects signatures that include one of these values. 

This breaks when a `ResourceType` field is non-empty in an `UploadParams` struct for a request; it gets marshaled as  `resource_type` and included in the signature, which doesn't match the server's logic.

#### What does this PR address?

- [x] GitHub issue #26
- [ ] Refactoring
- [ ] New feature
- [x] Bug fix
- [ ] Adds more tests

#### Are tests included?

- [x] Yes
- [ ] No

#### Reviewer, please note:

<!--
List anything here that the reviewer should pay special attention to. This might
include, for example:
* Dependence on other PRs
* Reference to other Cloudinary SDKs
* Changes that seem arbitrary without further explanations
-->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I ran the full test suite before pushing the changes and all the tests pass.
