### PR TITLE
Add support for reorder_metadata_fields Admin API

### DIFF
--- a/api/admin/api.go
+++ b/api/admin/api.go
@@ -38,6 +38,9 @@ const (
 type OrderByField string
 
 const OrderFieldValue OrderByField = "value"
+const OrderFieldLabel OrderByField = "label"
+const OrderFieldExternalID OrderByField = "external_id"
+const OrderFieldCreatedAt OrderByField = "created_at"
 
 // New creates a new Admin API instance from the environment variable (CLOUDINARY_URL).
 func New() (*API, error) {

--- a/api/admin/metadata_fields.go
+++ b/api/admin/metadata_fields.go
@@ -234,7 +234,7 @@ func (a *API) ReorderMetadataFields(ctx context.Context, params ReorderMetadataF
 	return res, err
 }
 
-// RestoreDatasourceEntriesResult is the result of ReorderMetadataFields.
+// ReorderMetadataFieldsResult is the result of ReorderMetadataFields.
 type ReorderMetadataFieldsResult struct {
 	MetadataFields []metadata.Field `json:"metadata_fields"`
 	Error          api.ErrorResp    `json:"error,omitempty"`

--- a/api/admin/metadata_fields.go
+++ b/api/admin/metadata_fields.go
@@ -219,3 +219,24 @@ type ReorderMetadataFieldDatasourceResult struct {
 	Error    api.ErrorResp `json:"error,omitempty"`
 	Response interface{}
 }
+
+// ReorderMetadataFieldsParams are the parameters for ReorderMetadataFields.
+type ReorderMetadataFieldsParams struct {
+	FieldOrderBy   OrderByField `json:"order_by"`
+	FieldDirection Direction    `json:"direction,omitempty"`
+}
+
+// ReorderMetadataFields reorders metadata fields.
+func (a *API) ReorderMetadataFields(ctx context.Context, params ReorderMetadataFieldsParams) (*ReorderMetadataFieldsResult, error) {
+	res := &ReorderMetadataFieldsResult{}
+	_, err := a.put(ctx, api.BuildPath(metadataFields, order), params, res)
+
+	return res, err
+}
+
+// RestoreDatasourceEntriesResult is the result of ReorderMetadataFields.
+type ReorderMetadataFieldsResult struct {
+	MetadataFields []metadata.Field `json:"metadata_fields"`
+	Error          api.ErrorResp    `json:"error,omitempty"`
+	Response       interface{}
+}

--- a/api/admin/metadata_fields_test.go
+++ b/api/admin/metadata_fields_test.go
@@ -154,6 +154,28 @@ func TestAdmin_ReorderMetadataFieldsDatasource(t *testing.T) {
 	}
 }
 
+func TestAdmin_ReorderMetadataFields(t *testing.T) {
+	// FIXME: do not use resp if err is not nil
+
+	resp, err := adminAPI.ReorderMetadataFields(ctx, admin.ReorderMetadataFieldsParams{FieldOrderBy: admin.OrderFieldLabel, FieldDirection: admin.Ascending})
+
+	if err != nil {
+		t.Error(err, resp)
+	}
+
+	resp, err = adminAPI.ReorderMetadataFields(ctx, admin.ReorderMetadataFieldsParams{FieldOrderBy: admin.OrderFieldExternalID, FieldDirection: admin.Descending})
+
+	if err != nil {
+		t.Error(err, resp)
+	}
+
+	resp, err = adminAPI.ReorderMetadataFields(ctx, admin.ReorderMetadataFieldsParams{FieldOrderBy: admin.OrderFieldCreatedAt, FieldDirection: admin.Ascending})
+
+	if err != nil {
+		t.Error(err, resp)
+	}
+}
+
 func TestAdmin_DeleteMetadataField(t *testing.T) {
 	resp, err := adminAPI.DeleteMetadataField(ctx, admin.DeleteMetadataFieldParams{FieldExternalID: metadataField.ExternalID})
 


### PR DESCRIPTION
### Brief Summary of Changes

<!-- Provide some context as to what was changed, from an implementation standpoint. -->

#### What does this PR address?

- [ ] GitHub issue (Add reference - #XX)
- [ ] Refactoring
- [x] New feature
- [ ] Bug fix
- [ ] Adds more tests

#### Are tests included?

- [x] Yes
- [ ] No

#### Reviewer, please note:

<!--
List anything here that the reviewer should pay special attention to. This might
include, for example:
* Dependence on other PRs
* Reference to other Cloudinary SDKs
* Changes that seem arbitrary without further explanations
-->

- Tests do not use mocks as other SDKs do and call the real API instead.
- Tests access `resp` as *other tests do*, but `resp` must not be accessed in `err` is not nil, and it seems that style of all tests has to be reviewed.

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I ran the full test suite before pushing the changes and all the tests pass.
