### PR TITLE
Add support for `AuthToken`

### DIFF
--- a/asset/asset_test.go
+++ b/asset/asset_test.go
@@ -28,9 +28,10 @@ func TestAsset_LongURLSignature(t *testing.T) {
 }
 
 func TestAsset_WithAuthToken(t *testing.T) {
+	localTokenConfig := authTokenConfig
 	i := getTestImage(t)
 	i.Config.URL.SignURL = true
-	i.AuthToken.Config = &authTokenConfig
+	i.AuthToken.Config = &localTokenConfig
 
 	assert.Contains(t, getAssetUrl(t, i), "1751370bcc6cfe9e03f30dd1a9722ba0f2cdca283fa3e6df3342a00a7528cc51")
 	assert.NotContains(t, getAssetUrl(t, i), "s--") // no simple signature

--- a/asset/asset_test.go
+++ b/asset/asset_test.go
@@ -27,6 +27,19 @@ func TestAsset_LongURLSignature(t *testing.T) {
 	assert.Regexp(t, "s--.{32}--", getAssetUrl(t, i))
 }
 
+func TestAsset_WithAuthToken(t *testing.T) {
+	i := getTestImage(t)
+	i.Config.URL.SignURL = true
+	i.AuthToken.Config = &authTokenConfig
+
+	assert.Contains(t, getAssetUrl(t, i), "1751370bcc6cfe9e03f30dd1a9722ba0f2cdca283fa3e6df3342a00a7528cc51")
+	assert.NotContains(t, getAssetUrl(t, i), "s--")
+
+	i.AuthToken.Config.ACL = ""
+
+	assert.Contains(t, getAssetUrl(t, i), "bdef2f6869faa4cde0f5d943440df9a592301a6e695a0e82687eb5bbaccd12f4")
+}
+
 func TestAsset_ForceVersion(t *testing.T) {
 	i, err := asset.Image(cldtest.ImageInFolder, nil)
 	if err != nil {

--- a/asset/asset_test.go
+++ b/asset/asset_test.go
@@ -33,7 +33,8 @@ func TestAsset_WithAuthToken(t *testing.T) {
 	i.AuthToken.Config = &authTokenConfig
 
 	assert.Contains(t, getAssetUrl(t, i), "1751370bcc6cfe9e03f30dd1a9722ba0f2cdca283fa3e6df3342a00a7528cc51")
-	assert.NotContains(t, getAssetUrl(t, i), "s--")
+	assert.NotContains(t, getAssetUrl(t, i), "s--") // no simple signature
+	assert.NotContains(t, getAssetUrl(t, i), "_a=") // no analytics
 
 	i.AuthToken.Config.ACL = ""
 

--- a/asset/auth_token.go
+++ b/asset/auth_token.go
@@ -17,7 +17,7 @@ const authTokenSeparator = "~"
 const authTokenInnerSeparator = "="
 
 type AuthToken struct {
-	Config config.AuthToken
+	Config *config.AuthToken
 }
 
 func (a AuthToken) isEnabled() bool {

--- a/asset/auth_token_test.go
+++ b/asset/auth_token_test.go
@@ -1,6 +1,7 @@
-package asset
+package asset_test
 
 import (
+	"github.com/cloudinary/cloudinary-go/asset"
 	"github.com/cloudinary/cloudinary-go/config"
 	"github.com/cloudinary/cloudinary-go/internal/cldtest"
 	"github.com/stretchr/testify/assert"
@@ -25,7 +26,7 @@ var authTokenConfig = config.AuthToken{
 }
 
 func TestAsset_AuthToken_GenerateWithStartTimeAndDuration(t *testing.T) {
-	a := AuthToken{Config: authTokenConfig}
+	a := asset.AuthToken{Config: &authTokenConfig}
 
 	expectedToken := "__cld_token__=st=1111111111~exp=1111111411~acl=%2fimage%2f*" +
 		"~hmac=1751370bcc6cfe9e03f30dd1a9722ba0f2cdca283fa3e6df3342a00a7528cc51"
@@ -34,13 +35,13 @@ func TestAsset_AuthToken_GenerateWithStartTimeAndDuration(t *testing.T) {
 }
 
 func TestAsset_AuthToken_MustProvideExpirationOrDuration(t *testing.T) {
-	a := AuthToken{Config: config.AuthToken{Key: authTokenKey}}
+	a := asset.AuthToken{Config: &config.AuthToken{Key: authTokenKey}}
 
 	assert.Panics(t, func() { a.Generate("") })
 }
 
 func TestAsset_AuthToken_ShouldIgnoreUrlIfAclIsProvided(t *testing.T) {
-	a := AuthToken{Config: authTokenConfig}
+	a := asset.AuthToken{Config: &authTokenConfig}
 	aclToken := a.Generate("")
 	aclTokenUrlIgnored := a.Generate(cldtest.PublicID)
 
@@ -53,8 +54,10 @@ func TestAsset_AuthToken_ShouldIgnoreUrlIfAclIsProvided(t *testing.T) {
 }
 
 func TestAsset_AuthToken_EscapeToLower(t *testing.T) {
+	a := asset.AuthToken{Config: &authTokenConfig}
+	a.Config.ACL = ""
 
-	expected := "Encode%20these%20%3a%7e%40%23%25%5e%26%7b%7d%5b%5d%5c%22%27%3b%2f%22,%20but%20not%20those%20$!()_.*"
+	expected := "__cld_token__=st=1111111111~exp=1111111411~hmac=9ee78e220dd8099445b0640986d4255ff2ff4d04609c55c8812d2d2490a0d509"
 
-	assert.Equal(t, escapeToLower("Encode these :~@#%^&{}[]\\\"';/\", but not those $!()_.*"), expected)
+	assert.Equal(t, expected, a.Generate("Encode these :~@#%^&{}[]\\\"';/\", but not those $!()_.*"))
 }


### PR DESCRIPTION
AuthToken feature was implemented in Go SDK, but was not integrated with the asset URL generation.

This PR adds support for the AuthToken and takes into consideration Analytics (which should be disabled when AuthToken is present)

### Brief Summary of Changes

<!-- Provide some context as to what was changed, from an implementation standpoint. -->

#### What does this PR address?

- [ ] GitHub issue (Add reference - #XX)
- [ ] Refactoring
- [x] New feature
- [ ] Bug fix
- [ ] Adds more tests

#### Are tests included?

- [x] Yes
- [ ] No

#### Reviewer, please note:

<!--
List anything here that the reviewer should pay special attention to. This might
include, for example:
* Dependence on other PRs
* Reference to other Cloudinary SDKs
* Changes that seem arbitrary without further explanations
-->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I ran the full test suite before pushing the changes and all the tests pass.
