### PR TITLE
Fix support for custom `timestamp` in `api.SignParameters`

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -246,7 +246,9 @@ func BuildPath(parts ...interface{}) string {
 
 // SignParameters signs parameters using the provided secret.
 func SignParameters(params url.Values, secret string) (string, error) {
-	params.Set("timestamp", strconv.FormatInt(time.Now().Unix(), 10))
+	if !params.Has("timestamp") || params["timestamp"][0] == "0" {
+		params.Set("timestamp", strconv.FormatInt(time.Now().Unix(), 10))
+	}
 
 	encodedUnescapedParams, err := url.QueryUnescape(params.Encode())
 	if err != nil {

--- a/api/api.go
+++ b/api/api.go
@@ -246,7 +246,7 @@ func BuildPath(parts ...interface{}) string {
 
 // SignParameters signs parameters using the provided secret.
 func SignParameters(params url.Values, secret string) (string, error) {
-	if !params.Has("timestamp") || params["timestamp"][0] == "0" {
+	if _, withTimestamp := params["timestamp"]; !withTimestamp || params["timestamp"][0] == "0" {
 		params.Set("timestamp", strconv.FormatInt(time.Now().Unix(), 10))
 	}
 

--- a/api/uploader/upload_acceptance_test.go
+++ b/api/uploader/upload_acceptance_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/cloudinary/cloudinary-go/v2/config"
 	"github.com/cloudinary/cloudinary-go/v2/internal/cldtest"
 	"testing"
-	"time"
 )
 
 var oAuthTokenConfig, _ = config.NewFromOAuthToken("TEST", "MTQ0NjJkZmQ5OTM2NDE1ZTZjNGZmZjI4")
@@ -86,7 +85,7 @@ func getFolderDecouplingTestCases() []UploadAPIAcceptanceTestCase {
 					AssetFolder:              "asset_folder",
 					UseFilenameAsDisplayName: api.Bool(true),
 					Unsigned:                 api.Bool(true),
-					Timestamp:                time.Unix(123456789, 0),
+					Timestamp:                123456789,
 				})
 			},
 			ResponseTest: func(response interface{}, t *testing.T) {},
@@ -112,7 +111,7 @@ func getBooleanValuesTestCases() []UploadAPIAcceptanceTestCase {
 					UniqueFilename: api.Bool(false),
 					UseFilename:    api.Bool(true),
 					Unsigned:       api.Bool(true),
-					Timestamp:      time.Unix(123456789, 0),
+					Timestamp:      123456789,
 				})
 			},
 			ResponseTest: func(response interface{}, t *testing.T) {},

--- a/api/uploader/upload_acceptance_test.go
+++ b/api/uploader/upload_acceptance_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/cloudinary/cloudinary-go/v2/config"
 	"github.com/cloudinary/cloudinary-go/v2/internal/cldtest"
 	"testing"
+	"time"
 )
 
 var oAuthTokenConfig, _ = config.NewFromOAuthToken("TEST", "MTQ0NjJkZmQ5OTM2NDE1ZTZjNGZmZjI4")
@@ -72,7 +73,7 @@ func getAuthorizationTestCases() []UploadAPIAcceptanceTestCase {
 
 // Acceptance test cases for folder decoupling
 func getFolderDecouplingTestCases() []UploadAPIAcceptanceTestCase {
-	body := "asset_folder=asset_folder&display_name=test&file=data%3Aimage%2Fgif%3Bbase64%2CR0lGODlhAQABAIAAAAAAAP%2F%2F%2FyH5BAEAAAAALAAAAAABAAEAAAIBRAA7&folder=folder%2Ftest&public_id_prefix=fd_public_id_prefix&timestamp=0001-01-01T00%3A00%3A00Z&unsigned=true&use_filename_as_display_name=true"
+	body := "asset_folder=asset_folder&display_name=test&file=data%3Aimage%2Fgif%3Bbase64%2CR0lGODlhAQABAIAAAAAAAP%2F%2F%2FyH5BAEAAAAALAAAAAABAAEAAAIBRAA7&folder=folder%2Ftest&public_id_prefix=fd_public_id_prefix&timestamp=123456789&unsigned=true&use_filename_as_display_name=true"
 
 	return []UploadAPIAcceptanceTestCase{
 		{
@@ -85,6 +86,7 @@ func getFolderDecouplingTestCases() []UploadAPIAcceptanceTestCase {
 					AssetFolder:              "asset_folder",
 					UseFilenameAsDisplayName: api.Bool(true),
 					Unsigned:                 api.Bool(true),
+					Timestamp:                time.Unix(123456789, 0),
 				})
 			},
 			ResponseTest: func(response interface{}, t *testing.T) {},
@@ -100,7 +102,7 @@ func getFolderDecouplingTestCases() []UploadAPIAcceptanceTestCase {
 
 // Acceptance test cases for handling of boolean values
 func getBooleanValuesTestCases() []UploadAPIAcceptanceTestCase {
-	body := "file=data%3Aimage%2Fgif%3Bbase64%2CR0lGODlhAQABAIAAAAAAAP%2F%2F%2FyH5BAEAAAAALAAAAAABAAEAAAIBRAA7&timestamp=0001-01-01T00%3A00%3A00Z&unique_filename=false&unsigned=true&use_filename=true"
+	body := "file=data%3Aimage%2Fgif%3Bbase64%2CR0lGODlhAQABAIAAAAAAAP%2F%2F%2FyH5BAEAAAAALAAAAAABAAEAAAIBRAA7&timestamp=123456789&unique_filename=false&unsigned=true&use_filename=true"
 
 	return []UploadAPIAcceptanceTestCase{
 		{
@@ -110,6 +112,7 @@ func getBooleanValuesTestCases() []UploadAPIAcceptanceTestCase {
 					UniqueFilename: api.Bool(false),
 					UseFilename:    api.Bool(true),
 					Unsigned:       api.Bool(true),
+					Timestamp:      time.Unix(123456789, 0),
 				})
 			},
 			ResponseTest: func(response interface{}, t *testing.T) {},

--- a/api/uploader/upload_asset.go
+++ b/api/uploader/upload_asset.go
@@ -69,6 +69,24 @@ type UploadParams struct {
 	CinemagraphAnalysis      *bool                       `json:"cinemagraph_analysis,omitempty"`
 }
 
+// MarshalJSON is used to customize serialization of the struct.
+func (u UploadParams) MarshalJSON() ([]byte, error) {
+	type UploadParamsAlias UploadParams
+
+	var timestamp int64
+	if !u.Timestamp.IsZero() {
+		timestamp = u.Timestamp.Unix()
+	}
+
+	return json.Marshal(&struct {
+		Timestamp int64 `json:"timestamp,omitempty"`
+		UploadParamsAlias
+	}{
+		Timestamp:         timestamp,
+		UploadParamsAlias: (UploadParamsAlias)(u),
+	})
+}
+
 // SingleResponsiveBreakpointsParams represents params for a single responsive breakpoints generation request.
 type SingleResponsiveBreakpointsParams struct {
 	CreateDerived  *bool  `json:"create_derived"`

--- a/api/uploader/upload_asset.go
+++ b/api/uploader/upload_asset.go
@@ -63,28 +63,10 @@ type UploadParams struct {
 	BackgroundRemoval        string                      `json:"background_removal,omitempty"`
 	Detection                string                      `json:"detection,omitempty"`
 	OCR                      string                      `json:"ocr,omitempty"`
-	Timestamp                time.Time                   `json:"timestamp,omitempty"`
+	Timestamp                int64                       `json:"timestamp,omitempty"`
 	QualityAnalysis          *bool                       `json:"quality_analysis,omitempty"`
 	AccessibilityAnalysis    *bool                       `json:"accessibility_analysis,omitempty"`
 	CinemagraphAnalysis      *bool                       `json:"cinemagraph_analysis,omitempty"`
-}
-
-// MarshalJSON is used to customize serialization of the struct.
-func (u UploadParams) MarshalJSON() ([]byte, error) {
-	type UploadParamsAlias UploadParams
-
-	var timestamp int64
-	if !u.Timestamp.IsZero() {
-		timestamp = u.Timestamp.Unix()
-	}
-
-	return json.Marshal(&struct {
-		Timestamp int64 `json:"timestamp,omitempty"`
-		UploadParamsAlias
-	}{
-		Timestamp:         timestamp,
-		UploadParamsAlias: (UploadParamsAlias)(u),
-	})
 }
 
 // SingleResponsiveBreakpointsParams represents params for a single responsive breakpoints generation request.

--- a/api/uploader/upload_asset_test.go
+++ b/api/uploader/upload_asset_test.go
@@ -33,7 +33,7 @@ func TestUploader_UploadLocalPath(t *testing.T) {
 		AccessibilityAnalysis: api.Bool(true),
 		CinemagraphAnalysis:   api.Bool(true),
 		Overwrite:             api.Bool(true),
-		Timestamp:             time.Now(),
+		Timestamp:             time.Now().Unix(),
 	}
 
 	resp, err := uploadAPI.Upload(ctx, cldtest.ImageFilePath, params)

--- a/api/uploader/upload_asset_test.go
+++ b/api/uploader/upload_asset_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 
@@ -32,6 +33,7 @@ func TestUploader_UploadLocalPath(t *testing.T) {
 		AccessibilityAnalysis: api.Bool(true),
 		CinemagraphAnalysis:   api.Bool(true),
 		Overwrite:             api.Bool(true),
+		Timestamp:             time.Now(),
 	}
 
 	resp, err := uploadAPI.Upload(ctx, cldtest.ImageFilePath, params)


### PR DESCRIPTION
### Brief Summary of Changes

<!-- Provide some context as to what was changed, from an implementation standpoint. -->

#### What does this PR address?

- [ ] GitHub issue (Add reference - #XX)
- [ ] Refactoring
- [ ] New feature
- [x] Bug fix
- [ ] Adds more tests

#### Are tests included?

- [x] Yes
- [ ] No

#### Reviewer, please note:

<!--
List anything here that the reviewer should pay special attention to. This might
include, for example:
* Dependence on other PRs
* Reference to other Cloudinary SDKs
* Changes that seem arbitrary without further explanations
-->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I ran the full test suite before pushing the changes and all the tests pass.
