### PR TITLE
Fix support for multiple `PublicIDs` in `CreateArchive`

### DIFF
--- a/api/uploader/archive.go
+++ b/api/uploader/archive.go
@@ -48,7 +48,7 @@ type CreateArchiveParams struct {
 	NotificationURL         string           `json:"notification_url,omitempty"`
 	Phash                   string           `json:"phash,omitempty"`
 	Prefixes                api.CldAPIArray  `json:"prefixes,omitempty"`
-	PublicIDs               api.CldAPIArray  `json:"public_ids,omitempty"`
+	PublicIDs               []string         `json:"public_ids,omitempty"`
 	ResourceType            api.AssetType    `json:"-"`
 	SkipTransformationName  *bool            `json:"skip_transformation_name,omitempty"`
 	TargetFormat            ArchiveFormat    `json:"target_format,omitempty"`

--- a/api/uploader/archive_test.go
+++ b/api/uploader/archive_test.go
@@ -37,7 +37,7 @@ func TestUploader_DownloadZipURL(t *testing.T) {
 	cldtest.UploadTestAsset(t, cldtest.PublicID2)
 
 	params := uploader.CreateArchiveParams{
-		Tags:           cldtest.Tags,
+		PublicIDs:      []string{cldtest.PublicID, cldtest.PublicID2},
 		TargetPublicID: "goArchive",
 	}
 
@@ -50,6 +50,9 @@ func TestUploader_DownloadZipURL(t *testing.T) {
 	if arURL == "" {
 		t.Error(arURL)
 	}
+
+	assert.Contains(t, arURL, url.QueryEscape("public_ids[0]")+"="+cldtest.PublicID)
+	assert.Contains(t, arURL, url.QueryEscape("public_ids[1]")+"="+cldtest.PublicID2)
 }
 
 func TestUploader_DownloadFolder(t *testing.T) {


### PR DESCRIPTION
### Brief Summary of Changes

<!-- Provide some context as to what was changed, from an implementation standpoint. -->

#### What does this PR address?

- [ ] GitHub issue (Add reference - #XX)
- [ ] Refactoring
- [ ] New feature
- [x] Bug fix
- [ ] Adds more tests

#### Are tests included?

- [x] Yes
- [ ] No

#### Reviewer, please note:

<!--
List anything here that the reviewer should pay special attention to. This might
include, for example:
* Dependence on other PRs
* Reference to other Cloudinary SDKs
* Changes that seem arbitrary without further explanations
-->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I ran the full test suite before pushing the changes and all the tests pass.
