### PR TITLE
Add support for `AssetsByAssetFolder` Admin API

### DIFF
--- a/api/admin/asset.go
+++ b/api/admin/asset.go
@@ -51,6 +51,8 @@ type AssetResult struct {
 	AssetID               string                      `json:"asset_id"`
 	PublicID              string                      `json:"public_id"`
 	Format                string                      `json:"format"`
+	AssetFolder           string                      `json:"asset_folder"`
+	DisplayName           string                      `json:"display_name"`
 	Version               int                         `json:"version"`
 	ResourceType          string                      `json:"resource_type"`
 	Type                  string                      `json:"type"`
@@ -136,6 +138,9 @@ type UpdateAssetParams struct {
 	AssetType         api.AssetType        `json:"-"`
 	DeliveryType      api.DeliveryType     `json:"-"`
 	PublicID          string               `json:"-"`
+	AssetFolder       string               `json:"asset_folder,omitempty"`
+	DisplayName       string               `json:"display_name,omitempty"`
+	UniqueDisplayName *bool                `json:"unique_display_name,omitempty"`
 	ModerationStatus  api.ModerationStatus `json:"moderation_status,omitempty"`
 	RawConvert        string               `json:"raw_convert,omitempty"`
 	OCR               string               `json:"ocr,omitempty"`

--- a/api/admin/assets.go
+++ b/api/admin/assets.go
@@ -13,6 +13,7 @@ import (
 
 const (
 	assets        api.EndPoint = "resources"
+	byAssetFolder api.EndPoint = "by_asset_folder"
 	derivedAssets api.EndPoint = "derived_resources"
 	tags          api.EndPoint = "tags"
 	cldContext    api.EndPoint = "context"
@@ -153,6 +154,26 @@ type AssetsByIDsParams struct {
 func (a *API) AssetsByIDs(ctx context.Context, params AssetsByIDsParams) (*AssetsResult, error) {
 	res := &AssetsResult{}
 	_, err := a.get(ctx, api.BuildPath(assets, params.AssetType, params.DeliveryType), params, res)
+
+	return res, err
+}
+
+// AssetsByAssetFolderParams are the parameters for AssetsByAssetFolder.
+type AssetsByAssetFolderParams struct {
+	AssetFolder string `json:"asset_folder"`
+	Tags        *bool  `json:"tags,omitempty"`
+	Context     *bool  `json:"context,omitempty"`
+	Moderations *bool  `json:"moderations,omitempty"`
+	NextCursor  string `json:"next_cursor,omitempty"`
+	MaxResults  int    `json:"max_results,omitempty"`
+}
+
+// AssetsByAssetFolder lists assets in the specified asset folder.
+//
+// https://cloudinary.com/documentation/admin_api#get_resources
+func (a *API) AssetsByAssetFolder(ctx context.Context, params AssetsByAssetFolderParams) (*AssetsResult, error) {
+	res := &AssetsResult{}
+	_, err := a.get(ctx, api.BuildPath(assets, byAssetFolder), params, res)
 
 	return res, err
 }

--- a/api/admin/assets_test.go
+++ b/api/admin/assets_test.go
@@ -1,6 +1,7 @@
 package admin_test
 
 import (
+	"github.com/stretchr/testify/assert"
 	"testing"
 
 	"github.com/cloudinary/cloudinary-go/v2/api"
@@ -44,6 +45,24 @@ func TestAssets_AssetsByIDs(t *testing.T) {
 	if err != nil || len(resp.Assets) != 1 {
 		t.Error(err, resp)
 	}
+}
+
+func TestAssets_AssetsByAssetFolder(t *testing.T) {
+	cldtest.SkipFeature(t, cldtest.SkipDynamicFolders)
+
+	asset1 := cldtest.UploadTestAsset(t, cldtest.PublicID)
+	asset2 := cldtest.UploadTestAsset(t, cldtest.PublicID2)
+
+	resp, err := adminAPI.AssetsByAssetFolder(ctx, admin.AssetsByAssetFolderParams{
+		AssetFolder: cldtest.UniqueFolder,
+	})
+
+	if err != nil || len(resp.Assets) != 2 {
+		t.Error(err, resp)
+	}
+
+	assert.Equal(t, asset1.AssetFolder, resp.Assets[0].AssetFolder)
+	assert.Equal(t, asset2.AssetFolder, resp.Assets[1].AssetFolder)
 }
 
 func TestAssets_RestoreAssets(t *testing.T) {

--- a/api/admin/search.go
+++ b/api/admin/search.go
@@ -43,8 +43,11 @@ type SearchResult struct {
 // SearchAsset represents the details of a single asset that was found.
 type SearchAsset struct {
 	PublicID      string              `json:"public_id"`
+	AssetID       string              `json:"asset_id"`
 	Folder        string              `json:"folder"`
+	AssetFolder   string              `json:"asset_folder"`
 	Filename      string              `json:"filename"`
+	DisplayName   string              `json:"display_name"`
 	Format        string              `json:"format"`
 	Version       int                 `json:"version"`
 	ResourceType  string              `json:"resource_type"`

--- a/api/admin/search/search.go
+++ b/api/admin/search/search.go
@@ -5,10 +5,10 @@ type Query struct {
 	// Expression is the (Lucene-like) string expression specifying the search query.
 	// If not provided then all resources are listed (up to MaxResults).
 	Expression string `json:"expression,omitempty"`
-	// SortBy is the the field to sort by. You can specify more than one SortBy parameter; results will be sorted
+	// SortBy is the field to sort by. You can specify more than one SortBy parameter; results will be sorted
 	// according to the order of the fields provided.
 	SortBy []SortByField `json:"sort_by,omitempty"`
-	// Aggregate is the the name of a field (attribute) for which an aggregation count should be calculated and returned in the response.
+	// Aggregate is the name of a field (attribute) for which an aggregation count should be calculated and returned in the response.
 	// (Tier 2 only)
 	// You can specify more than one aggregate parameter.
 	// For aggregation fields without discrete values, the results are divided into categories.

--- a/api/api.go
+++ b/api/api.go
@@ -167,6 +167,8 @@ type Metadata map[string]interface{}
 type BriefAssetResult struct {
 	AssetID     string    `json:"asset_id"`
 	PublicID    string    `json:"public_id"`
+	AssetFolder string    `json:"asset_folder"`
+	DisplayName string    `json:"display_name"`
 	Format      string    `json:"format"`
 	Version     int       `json:"version"`
 	AssetType   string    `json:"resource_type"`

--- a/api/uploader/upload_acceptance_test.go
+++ b/api/uploader/upload_acceptance_test.go
@@ -72,20 +72,22 @@ func getAuthorizationTestCases() []UploadAPIAcceptanceTestCase {
 
 // Acceptance test cases for folder decoupling
 func getFolderDecouplingTestCases() []UploadAPIAcceptanceTestCase {
-	body := "asset_folder=asset_folder&display_name=test&file=data%3Aimage%2Fgif%3Bbase64%2CR0lGODlhAQABAIAAAAAAAP%2F%2F%2FyH5BAEAAAAALAAAAAABAAEAAAIBRAA7&folder=folder%2Ftest&public_id_prefix=fd_public_id_prefix&timestamp=123456789&unsigned=true&use_filename_as_display_name=true"
+	body := "asset_folder=asset_folder&display_name=test&file=data%3Aimage%2Fgif%3Bbase64%2CR0lGODlhAQABAIAAAAAAAP%2F%2F%2FyH5BAEAAAAALAAAAAABAAEAAAIBRAA7&folder=folder%2Ftest&public_id_prefix=fd_public_id_prefix&timestamp=123456789&unique_display_name=true&unsigned=true&use_asset_folder_as_public_id_prefix=true&use_filename_as_display_name=true"
 
 	return []UploadAPIAcceptanceTestCase{
 		{
 			Name: "Upload Test Folder Decoupling",
 			RequestTest: func(uploadAPI *uploader.API, ctx context.Context) (interface{}, error) {
 				return uploadAPI.Upload(ctx, cldtest.Base64Image, uploader.UploadParams{
-					PublicIDPrefix:           "fd_public_id_prefix",
-					DisplayName:              "test",
-					Folder:                   "folder/test",
-					AssetFolder:              "asset_folder",
-					UseFilenameAsDisplayName: api.Bool(true),
-					Unsigned:                 api.Bool(true),
-					Timestamp:                123456789,
+					PublicIDPrefix:                 "fd_public_id_prefix",
+					DisplayName:                    "test",
+					UniqueDisplayName:              api.Bool(true),
+					Folder:                         "folder/test",
+					AssetFolder:                    "asset_folder",
+					UseAssetFolderAsPublicIDPrefix: api.Bool(true),
+					UseFilenameAsDisplayName:       api.Bool(true),
+					Unsigned:                       api.Bool(true),
+					Timestamp:                      123456789,
 				})
 			},
 			ResponseTest: func(response interface{}, t *testing.T) {},

--- a/api/uploader/upload_asset.go
+++ b/api/uploader/upload_asset.go
@@ -14,59 +14,61 @@ import (
 //
 // https://cloudinary.com/documentation/image_upload_api_reference#upload_optional_parameters
 type UploadParams struct {
-	PublicID                 string                      `json:"public_id,omitempty"`
-	PublicIDPrefix           string                      `json:"public_id_prefix,omitempty"`
-	PublicIDs                api.CldAPIArray             `json:"public_ids,omitempty"`
-	UseFilename              *bool                       `json:"use_filename,omitempty"`
-	UniqueFilename           *bool                       `json:"unique_filename,omitempty"`
-	DisplayName              string                      `json:"display_name,omitempty"`
-	UseFilenameAsDisplayName *bool                       `json:"use_filename_as_display_name,omitempty"`
-	FilenameOverride         string                      `json:"filename_override,omitempty"`
-	Folder                   string                      `json:"folder,omitempty"`
-	AssetFolder              string                      `json:"asset_folder,omitempty"`
-	Overwrite                *bool                       `json:"overwrite,omitempty"`
-	ResourceType             string                      `json:"resource_type,omitempty"`
-	Type                     api.DeliveryType            `json:"type,omitempty"`
-	Tags                     api.CldAPIArray             `json:"tags,omitempty"`
-	Context                  api.CldAPIMap               `json:"context,omitempty"`
-	Metadata                 api.Metadata                `json:"metadata,omitempty"`
-	Transformation           string                      `json:"transformation,omitempty"`
-	Format                   string                      `json:"format,omitempty"`
-	AllowedFormats           api.CldAPIArray             `json:"allowed_formats,omitempty"`
-	Eager                    string                      `json:"eager,omitempty"`
-	ResponsiveBreakpoints    ResponsiveBreakpointsParams `json:"responsive_breakpoints,omitempty"`
-	Eval                     string                      `json:"eval,omitempty"`
-	Async                    *bool                       `json:"async,omitempty"`
-	EagerAsync               *bool                       `json:"eager_async,omitempty"`
-	Unsigned                 *bool                       `json:"unsigned,omitempty"`
-	Proxy                    string                      `json:"proxy,omitempty"`
-	Headers                  string                      `json:"headers,omitempty"`
-	Callback                 string                      `json:"callback,omitempty"`
-	NotificationURL          string                      `json:"notification_url,omitempty"`
-	EagerNotificationURL     string                      `json:"eager_notification_url,omitempty"`
-	Faces                    *bool                       `json:"faces,omitempty"`
-	ImageMetadata            *bool                       `json:"image_metadata,omitempty"`
-	Exif                     *bool                       `json:"exif,omitempty"`
-	Colors                   *bool                       `json:"colors,omitempty"`
-	Phash                    *bool                       `json:"phash,omitempty"`
-	FaceCoordinates          api.Coordinates             `json:"face_coordinates,omitempty"`
-	CustomCoordinates        api.Coordinates             `json:"custom_coordinates,omitempty"`
-	Backup                   *bool                       `json:"backup,omitempty"`
-	ReturnDeleteToken        *bool                       `json:"return_delete_token,omitempty"`
-	Invalidate               *bool                       `json:"invalidate,omitempty"`
-	DiscardOriginalFilename  *bool                       `json:"discard_original_filename,omitempty"`
-	Moderation               string                      `json:"moderation,omitempty"`
-	UploadPreset             string                      `json:"upload_preset,omitempty"`
-	RawConvert               string                      `json:"raw_convert,omitempty"`
-	Categorization           string                      `json:"categorization,omitempty"`
-	AutoTagging              float64                     `json:"auto_tagging,omitempty"`
-	BackgroundRemoval        string                      `json:"background_removal,omitempty"`
-	Detection                string                      `json:"detection,omitempty"`
-	OCR                      string                      `json:"ocr,omitempty"`
-	Timestamp                int64                       `json:"timestamp,omitempty"`
-	QualityAnalysis          *bool                       `json:"quality_analysis,omitempty"`
-	AccessibilityAnalysis    *bool                       `json:"accessibility_analysis,omitempty"`
-	CinemagraphAnalysis      *bool                       `json:"cinemagraph_analysis,omitempty"`
+	PublicID                       string                      `json:"public_id,omitempty"`
+	PublicIDPrefix                 string                      `json:"public_id_prefix,omitempty"`
+	PublicIDs                      api.CldAPIArray             `json:"public_ids,omitempty"`
+	UseFilename                    *bool                       `json:"use_filename,omitempty"`
+	UniqueFilename                 *bool                       `json:"unique_filename,omitempty"`
+	UseFilenameAsDisplayName       *bool                       `json:"use_filename_as_display_name,omitempty"`
+	FilenameOverride               string                      `json:"filename_override,omitempty"`
+	DisplayName                    string                      `json:"display_name,omitempty"`
+	UniqueDisplayName              *bool                       `json:"unique_display_name,omitempty"`
+	Folder                         string                      `json:"folder,omitempty"`
+	AssetFolder                    string                      `json:"asset_folder,omitempty"`
+	UseAssetFolderAsPublicIDPrefix *bool                       `json:"use_asset_folder_as_public_id_prefix,omitempty"`
+	Overwrite                      *bool                       `json:"overwrite,omitempty"`
+	ResourceType                   string                      `json:"resource_type,omitempty"`
+	Type                           api.DeliveryType            `json:"type,omitempty"`
+	Tags                           api.CldAPIArray             `json:"tags,omitempty"`
+	Context                        api.CldAPIMap               `json:"context,omitempty"`
+	Metadata                       api.Metadata                `json:"metadata,omitempty"`
+	Transformation                 string                      `json:"transformation,omitempty"`
+	Format                         string                      `json:"format,omitempty"`
+	AllowedFormats                 api.CldAPIArray             `json:"allowed_formats,omitempty"`
+	Eager                          string                      `json:"eager,omitempty"`
+	ResponsiveBreakpoints          ResponsiveBreakpointsParams `json:"responsive_breakpoints,omitempty"`
+	Eval                           string                      `json:"eval,omitempty"`
+	Async                          *bool                       `json:"async,omitempty"`
+	EagerAsync                     *bool                       `json:"eager_async,omitempty"`
+	Unsigned                       *bool                       `json:"unsigned,omitempty"`
+	Proxy                          string                      `json:"proxy,omitempty"`
+	Headers                        string                      `json:"headers,omitempty"`
+	Callback                       string                      `json:"callback,omitempty"`
+	NotificationURL                string                      `json:"notification_url,omitempty"`
+	EagerNotificationURL           string                      `json:"eager_notification_url,omitempty"`
+	Faces                          *bool                       `json:"faces,omitempty"`
+	ImageMetadata                  *bool                       `json:"image_metadata,omitempty"`
+	Exif                           *bool                       `json:"exif,omitempty"`
+	Colors                         *bool                       `json:"colors,omitempty"`
+	Phash                          *bool                       `json:"phash,omitempty"`
+	FaceCoordinates                api.Coordinates             `json:"face_coordinates,omitempty"`
+	CustomCoordinates              api.Coordinates             `json:"custom_coordinates,omitempty"`
+	Backup                         *bool                       `json:"backup,omitempty"`
+	ReturnDeleteToken              *bool                       `json:"return_delete_token,omitempty"`
+	Invalidate                     *bool                       `json:"invalidate,omitempty"`
+	DiscardOriginalFilename        *bool                       `json:"discard_original_filename,omitempty"`
+	Moderation                     string                      `json:"moderation,omitempty"`
+	UploadPreset                   string                      `json:"upload_preset,omitempty"`
+	RawConvert                     string                      `json:"raw_convert,omitempty"`
+	Categorization                 string                      `json:"categorization,omitempty"`
+	AutoTagging                    float64                     `json:"auto_tagging,omitempty"`
+	BackgroundRemoval              string                      `json:"background_removal,omitempty"`
+	Detection                      string                      `json:"detection,omitempty"`
+	OCR                            string                      `json:"ocr,omitempty"`
+	Timestamp                      int64                       `json:"timestamp,omitempty"`
+	QualityAnalysis                *bool                       `json:"quality_analysis,omitempty"`
+	AccessibilityAnalysis          *bool                       `json:"accessibility_analysis,omitempty"`
+	CinemagraphAnalysis            *bool                       `json:"cinemagraph_analysis,omitempty"`
 }
 
 // SingleResponsiveBreakpointsParams represents params for a single responsive breakpoints generation request.
@@ -172,6 +174,8 @@ type ResponsiveBreakpointsResult struct {
 type UploadResult struct {
 	AssetID               string                        `json:"asset_id"`
 	PublicID              string                        `json:"public_id"`
+	AssetFolder           string                        `json:"asset_folder"`
+	DisplayName           string                        `json:"display_name"`
 	Version               int                           `json:"version"`
 	VersionID             string                        `json:"version_id"`
 	Signature             string                        `json:"signature"`

--- a/cloudinary_test.go
+++ b/cloudinary_test.go
@@ -53,7 +53,7 @@ func TestCloudinary_Upload(t *testing.T) {
 		Overwrite:      api.Bool(true),
 	}
 
-	resp, err := c.Upload.Upload(ctx, "https://cloudinary-res.cloudinary.com/image/upload/cloudinary_logo.png", params)
+	resp, err := c.Upload.Upload(ctx, cldtest.LogoURL, params)
 
 	if err != nil {
 		t.Error("Uploader failed: ", err)

--- a/internal/cldtest/cldtest.go
+++ b/internal/cldtest/cldtest.go
@@ -69,6 +69,12 @@ const Transformation = "c_scale,w_500"
 // APIVersion is the version of the API.
 const APIVersion = "v1_1"
 
+// SkipDynamicFolders is the name of the dynamic folders feature we want to skip.
+const SkipDynamicFolders = "dynamic_folders"
+
+// UniqueFolder is the unique folder for the current test run.
+var UniqueFolder = UniqueID(Folder)
+
 // ImageInFolder is the test public ID in folder.
 var ImageInFolder = fmt.Sprintf("%s/%s", Folder, PublicID)
 
@@ -102,9 +108,10 @@ var stringMetadataField = metadata.Field{
 // UploadTestAsset uploads a test image asset for test purposes.
 func UploadTestAsset(t *testing.T, publicID string) *uploader.UploadResult {
 	params := uploader.UploadParams{
-		PublicID:  publicID,
-		Overwrite: api.Bool(true),
-		Tags:      Tags,
+		PublicID:    publicID,
+		Overwrite:   api.Bool(true),
+		Tags:        Tags,
+		AssetFolder: UniqueFolder,
 	}
 
 	resp, err := uploadAPI.Upload(ctx, LogoURL, params)
@@ -277,5 +284,12 @@ func GetTestHandler(response string, t *testing.T, callCounter *int, ep Expected
 		if err != nil {
 			t.Error(err)
 		}
+	}
+}
+
+func SkipFeature(t *testing.T, feature string) {
+	featuresToRun := strings.ToLower(os.Getenv("CLD_TEST_FEATURES"))
+	if featuresToRun != "all" && !strings.Contains(featuresToRun, feature) {
+		t.Skipf("Please enable %s feature in your account and set CLD_TEST_FEATURES environment variable", feature)
 	}
 }


### PR DESCRIPTION
### Brief Summary of Changes

Add support for `AssetsByAssetFolder` Admin API
Add support for `AssetFolder`, `DisplayName`, `UniqueDisplayName` and `UseAssetFolderAsPublicIDPrefix` parameters

#### What does this PR address?

- [ ] GitHub issue (Add reference - #XX)
- [ ] Refactoring
- [x] New feature
- [ ] Bug fix
- [ ] Adds more tests

#### Are tests included?

- [x] Yes
- [ ] No

#### Reviewer, please note:

<!--
List anything here that the reviewer should pay special attention to. This might
include, for example:
* Dependence on other PRs
* Reference to other Cloudinary SDKs
* Changes that seem arbitrary without further explanations
-->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I ran the full test suite before pushing the changes and all the tests pass.
