### PR TITLE
Clarify error message when unsupported file parameter is provided

### DIFF
--- a/api/uploader/upload.go
+++ b/api/uploader/upload.go
@@ -185,7 +185,7 @@ func (u *API) postFile(ctx context.Context, file interface{}, formParams url.Val
 	case io.Reader:
 		return u.postIOReader(ctx, uploadEndpoint, fileValue, "file", formParams, map[string]string{}, 0)
 	default:
-		return nil, errors.New("unsupported file type")
+		return nil, fmt.Errorf("invalid file parameter of unsupported type %T", file)
 	}
 }
 


### PR DESCRIPTION
Example of the previous error when additional error information was added by other layers of the cloudinary-go library:

`unsupported file type: (1882416 bytes) GIF89a�x��wl����� '�d/��1-���!�
NETSCAPE2.0!�`

This looks like Cloudinary doesn't support GIFs or the specific GIF I'm uploading, which is very confusing.

This message clarifies what is wrong and outputs the go type to make things clearer.