### PR TITLE
Fix `AuthToken` generation without ACL

### DIFF
--- a/asset/asset.go
+++ b/asset/asset.go
@@ -295,7 +295,7 @@ func (a *Asset) path() string {
 func (a *Asset) query() string {
 	// Currently, analytics is not supported with AuthToken. Just return AuthToken if it is configured.
 	if a.Config.URL.SignURL && a.AuthToken.isEnabled() {
-		return a.AuthToken.Generate(a.path())
+		return a.AuthToken.Generate("/" + a.path())
 	}
 
 	if !a.Config.URL.Analytics {

--- a/asset/asset_test.go
+++ b/asset/asset_test.go
@@ -28,18 +28,26 @@ func TestAsset_LongURLSignature(t *testing.T) {
 }
 
 func TestAsset_WithAuthToken(t *testing.T) {
-	localTokenConfig := authTokenConfig
-	i := getTestImage(t)
+	i, _ := asset.Image(authTokenTestImage, nil)
+	i.DeliveryType = api.Authenticated
+	i.Version = 1486020273
+
 	i.Config.URL.SignURL = true
+
+	localTokenConfig := authTokenConfig
 	i.AuthToken.Config = &localTokenConfig
 
+	i.AuthToken.Config.StartTime = 1111111111
+
 	assert.Contains(t, getAssetUrl(t, i), "1751370bcc6cfe9e03f30dd1a9722ba0f2cdca283fa3e6df3342a00a7528cc51")
+
 	assert.NotContains(t, getAssetUrl(t, i), "s--") // no simple signature
 	assert.NotContains(t, getAssetUrl(t, i), "_a=") // no analytics
 
 	i.AuthToken.Config.ACL = ""
+	i.AuthToken.Config.StartTime = startTime
 
-	assert.Contains(t, getAssetUrl(t, i), "bdef2f6869faa4cde0f5d943440df9a592301a6e695a0e82687eb5bbaccd12f4")
+	assert.Contains(t, getAssetUrl(t, i), "8db0d753ee7bbb9e2eaf8698ca3797436ba4c20e31f44527e43b6a6e995cfdb3")
 }
 
 func TestAsset_ForceVersion(t *testing.T) {

--- a/asset/auth_token.go
+++ b/asset/auth_token.go
@@ -66,21 +66,21 @@ func (a AuthToken) Generate(path string) string {
 }
 
 func (a AuthToken) handleLifetime() (int64, int64) {
-	start := a.Config.StartTime
 	expiration := a.Config.Expiration
-	if start == 0 {
-		start = time.Now().Unix()
-	}
 
 	if expiration == 0 {
 		if a.Config.Duration != 0 {
+			start := a.Config.StartTime
+			if start == 0 {
+				start = time.Now().Unix()
+			}
 			expiration = start + a.Config.Duration
 		} else {
 			panic("must provide Expiration or Duration")
 		}
 	}
 
-	return start, expiration
+	return a.Config.StartTime, expiration
 }
 
 func escapeToLower(str string) string {

--- a/asset/auth_token_test.go
+++ b/asset/auth_token_test.go
@@ -1,7 +1,6 @@
 package asset_test
 
 import (
-	"github.com/cloudinary/cloudinary-go/v2/api"
 	"github.com/cloudinary/cloudinary-go/v2/asset"
 	"github.com/cloudinary/cloudinary-go/v2/config"
 	"github.com/stretchr/testify/assert"
@@ -69,20 +68,4 @@ func TestAsset_AuthToken_EscapeToLower(t *testing.T) {
 	expected := "__cld_token__=st=11111111~exp=11111411~hmac=7ffc0fd1f3ee2622082689f64a65454da39d94c297bcf498b682aa65a0d2ce0a"
 
 	assert.Equal(t, expected, a.Generate("Encode these :~@#%^&{}[]\\\"';/\", but not those $!()_.*"))
-}
-
-func TestAsset_AuthToken_URLWithoutACL(t *testing.T) {
-	i, _ := asset.Image(authTokenTestImage, nil)
-
-	i.AuthToken.Config = &authTokenConfig
-	i.AuthToken.Config.ACL = ""
-
-	i.DeliveryType = api.Authenticated
-	i.Version = 1486020273
-	i.Config.URL.SignURL = true
-
-	expected := "__cld_token__=st=11111111~exp=11111411~hmac=8db0d753ee7bbb9e2eaf8698ca3797436ba4c20e31f44527e43b6a6e995cfdb3"
-
-	iURL, _ := i.String()
-	assert.Contains(t, iURL, expected)
 }

--- a/asset/auth_token_test.go
+++ b/asset/auth_token_test.go
@@ -1,9 +1,9 @@
 package asset_test
 
 import (
+	"github.com/cloudinary/cloudinary-go/v2/api"
 	"github.com/cloudinary/cloudinary-go/v2/asset"
 	"github.com/cloudinary/cloudinary-go/v2/config"
-	"github.com/cloudinary/cloudinary-go/v2/internal/cldtest"
 	"github.com/stretchr/testify/assert"
 	"testing"
 )
@@ -12,7 +12,7 @@ const authTokenKey = "00112233FF99"
 const authTokenAltKey = "CCBB2233FF00"
 
 const duration = 300
-const startTime = 1111111111
+const startTime = 11111111
 
 const authTokenTestImage = "sample.jpg"
 const authTokenTestConfigACL = "/*/t_foobar"
@@ -26,7 +26,9 @@ var authTokenConfig = config.AuthToken{
 }
 
 func TestAsset_AuthToken_GenerateWithStartTimeAndDuration(t *testing.T) {
-	a := asset.AuthToken{Config: &authTokenConfig}
+	newConfig := authTokenConfig
+	a := asset.AuthToken{Config: &newConfig}
+	a.Config.StartTime = 1111111111
 
 	expectedToken := "__cld_token__=st=1111111111~exp=1111111411~acl=%2fimage%2f*" +
 		"~hmac=1751370bcc6cfe9e03f30dd1a9722ba0f2cdca283fa3e6df3342a00a7528cc51"
@@ -40,14 +42,21 @@ func TestAsset_AuthToken_MustProvideExpirationOrDuration(t *testing.T) {
 	assert.Panics(t, func() { a.Generate("") })
 }
 
+func TestAsset_AuthToken_NoStartTimeRequired(t *testing.T) {
+	a := asset.AuthToken{Config: &config.AuthToken{Key: authTokenKey, Expiration: startTime + duration}}
+
+	expectedToken := "__cld_token__=exp=11111411~hmac=470d32e3ee9b872d64bd00d974c559d96892398c8542ff33ce2f2647ee1bf7a4"
+	assert.Equal(t, expectedToken, a.Generate(authTokenTestImage))
+}
+
 func TestAsset_AuthToken_ShouldIgnoreUrlIfAclIsProvided(t *testing.T) {
 	a := asset.AuthToken{Config: &authTokenConfig}
 	aclToken := a.Generate("")
-	aclTokenUrlIgnored := a.Generate(cldtest.PublicID)
+	aclTokenUrlIgnored := a.Generate(authTokenTestImage)
 
 	a.Config.ACL = ""
 
-	urlToken := a.Generate(cldtest.PublicID)
+	urlToken := a.Generate(authTokenTestImage)
 
 	assert.NotEqual(t, aclToken, urlToken)
 	assert.Equal(t, aclToken, aclTokenUrlIgnored)
@@ -57,7 +66,23 @@ func TestAsset_AuthToken_EscapeToLower(t *testing.T) {
 	a := asset.AuthToken{Config: &authTokenConfig}
 	a.Config.ACL = ""
 
-	expected := "__cld_token__=st=1111111111~exp=1111111411~hmac=9ee78e220dd8099445b0640986d4255ff2ff4d04609c55c8812d2d2490a0d509"
+	expected := "__cld_token__=st=11111111~exp=11111411~hmac=7ffc0fd1f3ee2622082689f64a65454da39d94c297bcf498b682aa65a0d2ce0a"
 
 	assert.Equal(t, expected, a.Generate("Encode these :~@#%^&{}[]\\\"';/\", but not those $!()_.*"))
+}
+
+func TestAsset_AuthToken_URLWithoutACL(t *testing.T) {
+	i, _ := asset.Image(authTokenTestImage, nil)
+
+	i.AuthToken.Config = &authTokenConfig
+	i.AuthToken.Config.ACL = ""
+
+	i.DeliveryType = api.Authenticated
+	i.Version = 1486020273
+	i.Config.URL.SignURL = true
+
+	expected := "__cld_token__=st=11111111~exp=11111411~hmac=8db0d753ee7bbb9e2eaf8698ca3797436ba4c20e31f44527e43b6a6e995cfdb3"
+
+	iURL, _ := i.String()
+	assert.Contains(t, iURL, expected)
 }


### PR DESCRIPTION
### Brief Summary of Changes

This PR fixes issue with AuthToken when ACL was not used.

#### What does this PR address?

- [ ] GitHub issue (Add reference - #XX)
- [ ] Refactoring
- [ ] New feature
- [x] Bug fix
- [ ] Adds more tests

#### Are tests included?

- [x] Yes
- [ ] No

#### Reviewer, please note:

<!--
List anything here that the reviewer should pay special attention to. This might
include, for example:
* Dependence on other PRs
* Reference to other Cloudinary SDKs
* Changes that seem arbitrary without further explanations
-->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I ran the full test suite before pushing the changes and all the tests pass.
