### PR TITLE
Add before send option

### DIFF
--- a/api/admin/api.go
+++ b/api/admin/api.go
@@ -198,6 +198,9 @@ func (a *API) executeRequest(ctx context.Context, method string, path interface{
 
 	req = req.WithContext(ctx)
 
+	if a.Config.API.BeforeSend != nil {
+		a.Config.API.BeforeSend(req)
+	}
 	resp, err := a.Client.Do(req)
 	if err != nil {
 		return nil, err

--- a/api/uploader/upload.go
+++ b/api/uploader/upload.go
@@ -350,6 +350,9 @@ func (u *API) postBody(ctx context.Context, urlPath interface{}, bodyReader io.R
 
 	req = req.WithContext(ctx)
 
+	if u.Config.API.BeforeSend != nil {
+		u.Config.API.BeforeSend(req)
+	}
 	resp, err := u.Client.Do(req)
 	if err != nil {
 		return nil, err

--- a/config/api.go
+++ b/config/api.go
@@ -1,9 +1,12 @@
 package config
 
+import "net/http"
+
 // API defines the configuration for making requests to the Cloudinary API.
 type API struct {
 	UploadPrefix  string `schema:"upload_prefix" default:"https://api.cloudinary.com"`
 	Timeout       int64  `schema:"timeout" default:"60"` // seconds
 	UploadTimeout int64  `schema:"upload_timeout"`
 	ChunkSize     int64  `schema:"chunk_size" default:"20000000"` // bytes
+	BeforeSend    func(req *http.Request)
 }


### PR DESCRIPTION
### Brief Summary of Changes

<!-- Provide some context as to what was changed, from an implementation standpoint. -->
I'd like to be able to do adjustments to the request before it's sent to an API - things like adding custom headers etc. To achieve that I added an optional function BeforeSend that will be called right before a request is sent.

#### What does this PR address?

- [ ] GitHub issue (Add reference - #XX)
- [ ] Refactoring
- [x] New feature
- [ ] Bug fix
- [ ] Adds more tests

#### Are tests included?

- [x] Yes
- [ ] No

#### Reviewer, please note:

<!--
List anything here that the reviewer should pay special attention to. This might
include, for example:
* Dependence on other PRs
* Reference to other Cloudinary SDKs
* Changes that seem arbitrary without further explanations
-->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I ran the full test suite before pushing the changes and all the tests pass.
