### PR TITLE
Do not sign upload without an API secret

### DIFF
--- a/api/uploader/upload.go
+++ b/api/uploader/upload.go
@@ -9,7 +9,6 @@ import (
 	"crypto/sha1"
 	"encoding/hex"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -96,14 +95,11 @@ func (u *API) postAndSignForm(ctx context.Context, urlPath string, formParams ur
 }
 
 func (u *API) signRequest(requestParams url.Values) (url.Values, error) {
-	// No signing for OAuth Token
-	if u.Config.Cloud.OAuthToken != "" {
+	// No signing for OAuth Token or when API Secret is missing
+	if u.Config.Cloud.OAuthToken != "" || u.Config.Cloud.APISecret == "" {
 		return requestParams, nil
 	}
 
-	if u.Config.Cloud.APISecret == "" {
-		return nil, errors.New("must provide API Secret")
-	}
 	// https://cloudinary.com/documentation/upload_images#generating_authentication_signatures
 	// All parameters added to the method call should be included except: file, cloud_name, resource_type and your api_key.
 


### PR DESCRIPTION
### Brief Summary of Changes

<!-- Provide some context as to what was changed, from an implementation standpoint. -->
If there is no API secret we should still attempt the upload, just without the signature.

#### What does this PR address?

- [ ] GitHub issue (Add reference - #XX)
- [ ] Refactoring
- [ ] New feature
- [ ] Bug fix
- [ ] Adds more tests

#### Are tests included?

- [ ] Yes
- [ ] No

#### Reviewer, please note:

<!--
List anything here that the reviewer should pay special attention to. This might
include, for example:
* Dependence on other PRs
* Reference to other Cloudinary SDKs
* Changes that seem arbitrary without further explanations
-->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I ran the full test suite before pushing the changes and all the tests pass.
