### PR TITLE
Add support for `Fields` in `AutoVideoDetails` upload parameter

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -186,7 +186,9 @@ func (at AutoTranscription) MarshalJSON() ([]byte, error) {
 }
 
 // AutoVideoDetails represents the auto video details param.
-type AutoVideoDetails struct{}
+type AutoVideoDetails struct {
+	Fields []string `json:"fields,omitempty"`
+}
 
 // BriefAssetResult represents a partial asset result that is returned when assets are listed.
 type BriefAssetResult struct {

--- a/api/uploader/upload_acceptance_test.go
+++ b/api/uploader/upload_acceptance_test.go
@@ -160,6 +160,10 @@ func getAutoVideoDetailsTestCases() []UploadAPIAcceptanceTestCase {
 		"&file=data%3Aimage%2Fgif%3Bbase64%2CR0lGODlhAQABAIAAAAAAAP%2F%2F%2FyH5BAEAAAAALAAAAAABAAEAAAIBRAA7" +
 		"&timestamp=123456789" +
 		"&unsigned=true"
+	bodyFields := "auto_video_details=%7B%22fields%22%3A%5B%22title%22%2C%22description%22%5D%7D" +
+		"&file=data%3Aimage%2Fgif%3Bbase64%2CR0lGODlhAQABAIAAAAAAAP%2F%2F%2FyH5BAEAAAAALAAAAAABAAEAAAIBRAA7" +
+		"&timestamp=123456789" +
+		"&unsigned=true"
 
 	return []UploadAPIAcceptanceTestCase{
 		{
@@ -176,6 +180,23 @@ func getAutoVideoDetailsTestCases() []UploadAPIAcceptanceTestCase {
 				Method: "POST",
 				URI:    "/auto/upload",
 				Body:   &bodyEmpty,
+			},
+			ExpectedCallCount: 1,
+		},
+		{
+			Name: "Upload Test Auto Video Details With Fields",
+			RequestTest: func(uploadAPI *uploader.API, ctx context.Context) (interface{}, error) {
+				return uploadAPI.Upload(ctx, cldtest.Base64Image, uploader.UploadParams{
+					AutoVideoDetails: &api.AutoVideoDetails{
+						Fields: []string{"title", "description"},
+					},
+				})
+			},
+			ResponseTest: func(response interface{}, t *testing.T) {},
+			ExpectedRequest: cldtest.ExpectedRequestParams{
+				Method: "POST",
+				URI:    "/auto/upload",
+				Body:   &bodyFields,
 			},
 			ExpectedCallCount: 1,
 		},


### PR DESCRIPTION
### Brief Summary of Changes

Add support for `Fields` in `AutoVideoDetails` upload parameter
<!-- Provide some context as to what was changed, from an implementation standpoint. -->

#### What does this PR address?

- [ ] GitHub issue (Add reference - #XX)
- [ ] Refactoring
- [x] New feature
- [ ] Bug fix
- [ ] Adds more tests

#### Are tests included?

- [x] Yes
- [ ] No

#### Reviewer, please note:

<!--
List anything here that the reviewer should pay special attention to. This might
include, for example:
* Dependence on other PRs
* Reference to other Cloudinary SDKs
* Changes that seem arbitrary without further explanations
-->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I ran the full test suite before pushing the changes and all the tests pass.
